### PR TITLE
Handle removal of django.utils.importlib

### DIFF
--- a/bootstrap3/bootstrap.py
+++ b/bootstrap3/bootstrap.py
@@ -2,7 +2,12 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.utils.importlib import import_module
+
+try:
+    from importlib import import_module
+except ImportError:
+    # this was removed in Django 1.8
+    from django.utils.importlib import import_module
 
 
 # Default settings


### PR DESCRIPTION
Django 1.8 requires Py2.7 which ships with a native importlib. Therefore, the removed the django.utils version in 1.8.
